### PR TITLE
Introduce new API - fully compatible with stdlib

### DIFF
--- a/fastcache/__init__.py
+++ b/fastcache/__init__.py
@@ -1,19 +1,19 @@
-""" C implementation of LRU caching. 
+""" C implementation of LRU caching.
 
 Provides 2 LRU caching function decorators:
 
 clru_cache - built-in (faster)
            >>> from fastcache import clru_cache
-           >>> @clru_cache(maxsize=128,typed=False,state=None)
+           >>> @clru_cache(maxsize=128,typed=False)
            ... def f(a, b):
            ...     return (a, )+(b, )
            ...
            >>> type(f)
-           >>> <class '_lrucache.cache'>
+           >>> <class 'fastcache.clru_cache'>
 
 lru_cache  - python wrapper around clru_cache (slower)
            >>> from fastcache import lru_cache
-           >>> @lru_cache(maxsize=128,typed=False,state=None)
+           >>> @lru_cache(maxsize=128,typed=False)
            ... def f(a, b):
            ...     return (a, )+(b, )
            ...
@@ -24,37 +24,48 @@ lru_cache  - python wrapper around clru_cache (slower)
 __version__ = "0.3.3"
 
 
-from ._lrucache import lrucache as clru_cache
+from ._lrucache import clru_cache
 from functools import update_wrapper
 
-def lru_cache(maxsize=128, typed=False, state=None):
+def lru_cache(maxsize=128, typed=False, state=None, unhashable='exception'):
     """Least-recently-used cache decorator.
 
-    If *maxsize* is set to None, the LRU features are disabled and the cache
-    can grow without bound.
+    If *maxsize* is set to None, the LRU features are disabled and
+    the cache can grow without bound.
 
-    If *typed* is True, arguments of different types will be cached separately.
-    For example, f(3.0) and f(3) will be treated as distinct calls with
-    distinct results.
+    If *typed* is True, arguments of different types will be cached
+    separately. For example, f(3.0) and f(3) will be treated as distinct
+    calls with distinct results.
 
-    If *state* is a list, the items in the list will be incorporated into 
+    If *state* is a list, the items in the list will be incorporated into
     argument hash.
 
-    Arguments to the cached function must be hashable.
+    The result of calling the cached function with unhashable (mutable)"
+    arguments depends on the value of *unhashable*:
+
+        If *unhashable* is 'exception', a TypeError will be raised.
+
+        If *unhashable* is 'warn', a UserWarning will be raised, and
+        the wrapped function will be called with the supplied arguments.
+        A miss will be recorded in the cache statistics.
+
+        If *unhashable* is 'ignore', the wrapped function will be called
+        with the supplied arguments. A miss will will be recorded in
+        the cache statistics.
 
     View the cache statistics named tuple (hits, misses, maxsize, currsize)
-    with f.cache_info().  Clear the cache and statistics with f.cache_clear().
-    Access the underlying function with f.__wrapped__.
+    with f.cache_info().  Clear the cache and statistics with
+    f.cache_clear(). Access the underlying function with f.__wrapped__.
 
     See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
 
     """
     def func_wrapper(func):
-        _cached_func = clru_cache(maxsize, typed, state)(func)
+        _cached_func = clru_cache(maxsize, typed, state, unhashable)(func)
 
         def wrapper(*args, **kwargs):
             return _cached_func(*args, **kwargs)
-            
+
         wrapper.__wrapped__ = func
         wrapper.cache_info = _cached_func.cache_info
         wrapper.cache_clear = _cached_func.cache_clear
@@ -62,4 +73,3 @@ def lru_cache(maxsize=128, typed=False, state=None):
         return update_wrapper(wrapper,func)
 
     return func_wrapper
-    

--- a/fastcache/tests/test_clrucache.py
+++ b/fastcache/tests/test_clrucache.py
@@ -75,10 +75,10 @@ class TestCLru_Cache(unittest.TestCase):
         for i, j in self.arg_gen(max=1500, repeat=5):
             self.assertEqual(cfunc(i, j, c=i-j), tfunc(i, j, c=i-j))
 
-    def test_hashable_args(self):
+    def test_warn_unhashable_args(self):
         """ Function arguments must be hashable. """
 
-        @lru_cache()
+        @lru_cache(unhashable='warn')
         def f(a, b):
             return (a, ) + (b, )
 
@@ -88,6 +88,22 @@ class TestCLru_Cache(unittest.TestCase):
         else:
             #with self.assertRaises(UserWarning) as cm:
             self.assertEqual(f([1], 2), f.__wrapped__([1], 2))
+
+    def test_ignore_unhashable_args(self):
+        """ Function arguments must be hashable. """
+
+        @lru_cache(unhashable='ignore')
+        def f(a, b):
+            return (a, ) + (b, )
+
+        self.assertEqual(f([1], 2), f.__wrapped__([1], 2))
+
+    def test_default_unhashable_args(self):
+        @lru_cache()
+        def f(a, b):
+            return (a, ) + (b, )
+
+        self.assertRaises(TypeError, f, [1], 2)
 
     def test_state_type(self):
         """ State must be a list. """

--- a/fastcache/tests/test_lrucache.py
+++ b/fastcache/tests/test_lrucache.py
@@ -10,7 +10,7 @@ except TypeError:
         i = step-1
         for j, c in enumerate(itertools.count(start)):
             yield c + i*j
-        
+
 class TestLru_Cache(unittest.TestCase):
     """ Tests for lru_cache. """
 
@@ -75,10 +75,10 @@ class TestLru_Cache(unittest.TestCase):
         for i, j in self.arg_gen(max=1500, repeat=5):
             self.assertEqual(cfunc(i, j, c=i-j), tfunc(i, j, c=i-j))
 
-    def test_hashable_args(self):
+    def test_warn_unhashable_args(self):
         """ Function arguments must be hashable. """
 
-        @lru_cache()
+        @lru_cache(unhashable='warn')
         def f(a, b):
             return (a, ) + (b, )
 
@@ -86,7 +86,24 @@ class TestLru_Cache(unittest.TestCase):
             with self.assertWarns(UserWarning) as cm:
                 self.assertEqual(f([1], 2), f.__wrapped__([1], 2))
         else:
+            #with self.assertRaises(UserWarning) as cm:
             self.assertEqual(f([1], 2), f.__wrapped__([1], 2))
+
+    def test_ignore_unhashable_args(self):
+        """ Function arguments must be hashable. """
+
+        @lru_cache(unhashable='ignore')
+        def f(a, b):
+            return (a, ) + (b, )
+
+        self.assertEqual(f([1], 2), f.__wrapped__([1], 2))
+
+    def test_default_unhashable_args(self):
+        @lru_cache()
+        def f(a, b):
+            return (a, ) + (b, )
+
+        self.assertRaises(TypeError, f, [1], 2)
 
     def test_state_type(self):
         """ State must be a list. """


### PR DESCRIPTION
*default behavior of fastcache is changed to raise TypeError on
 unhashable arguments to be 100% consistent with stdlib.
*introduce a new argument 'unhashable' which can take the values
 'exception' (default), 'warn', and 'ignore' to modify the behavior
 of fastcache upon receiving unhashable arguments.
*Altered docstrings to highlight this

addresses #2 
