### PR TITLE
More consistent naming scheme for *unhashable*

### DIFF
--- a/fastcache/__init__.py
+++ b/fastcache/__init__.py
@@ -27,7 +27,7 @@ __version__ = "0.3.3"
 from ._lrucache import clru_cache
 from functools import update_wrapper
 
-def lru_cache(maxsize=128, typed=False, state=None, unhashable='exception'):
+def lru_cache(maxsize=128, typed=False, state=None, unhashable='error'):
     """Least-recently-used cache decorator.
 
     If *maxsize* is set to None, the LRU features are disabled and
@@ -40,12 +40,12 @@ def lru_cache(maxsize=128, typed=False, state=None, unhashable='exception'):
     If *state* is a list, the items in the list will be incorporated into
     argument hash.
 
-    The result of calling the cached function with unhashable (mutable)"
+    The result of calling the cached function with unhashable (mutable)
     arguments depends on the value of *unhashable*:
 
-        If *unhashable* is 'exception', a TypeError will be raised.
+        If *unhashable* is 'error', a TypeError will be raised.
 
-        If *unhashable* is 'warn', a UserWarning will be raised, and
+        If *unhashable* is 'warning', a UserWarning will be raised, and
         the wrapped function will be called with the supplied arguments.
         A miss will be recorded in the cache statistics.
 

--- a/fastcache/tests/test_clrucache.py
+++ b/fastcache/tests/test_clrucache.py
@@ -78,7 +78,7 @@ class TestCLru_Cache(unittest.TestCase):
     def test_warn_unhashable_args(self):
         """ Function arguments must be hashable. """
 
-        @lru_cache(unhashable='warn')
+        @lru_cache(unhashable='warning')
         def f(a, b):
             return (a, ) + (b, )
 
@@ -103,6 +103,11 @@ class TestCLru_Cache(unittest.TestCase):
         def f(a, b):
             return (a, ) + (b, )
 
+        self.assertRaises(TypeError, f, [1], 2)
+
+        @lru_cache(unhashable='error')
+        def f(a, b):
+            pass
         self.assertRaises(TypeError, f, [1], 2)
 
     def test_state_type(self):

--- a/fastcache/tests/test_lrucache.py
+++ b/fastcache/tests/test_lrucache.py
@@ -78,7 +78,7 @@ class TestLru_Cache(unittest.TestCase):
     def test_warn_unhashable_args(self):
         """ Function arguments must be hashable. """
 
-        @lru_cache(unhashable='warn')
+        @lru_cache(unhashable='warning')
         def f(a, b):
             return (a, ) + (b, )
 
@@ -103,6 +103,11 @@ class TestLru_Cache(unittest.TestCase):
         def f(a, b):
             return (a, ) + (b, )
 
+        self.assertRaises(TypeError, f, [1], 2)
+
+        @lru_cache(unhashable='error')
+        def f(a, b):
+            pass
         self.assertRaises(TypeError, f, [1], 2)
 
     def test_state_type(self):


### PR DESCRIPTION
exception  -> error    - since a `TypeError` is raised
warn         -> warning  - since a `UserWarning` is raised
ignore       -> ignore   - no change

See discussion in #2 
