### PR TITLE
Compile time flags can now be passed via build and install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
-  
+
 install: python setup.py install
 
 script: bash bin/test_travis.sh

--- a/fastcache/benchmark.py
+++ b/fastcache/benchmark.py
@@ -31,7 +31,7 @@ if sys.version_info[:2] >= (3, 3):
     def _arg_gen(min=1, max=100, repeat=3):
         for i in range(min, max):
             for r in range(repeat):
-                for j, k in zip(range(i), count(i, -1)): 
+                for j, k in zip(range(i), count(i, -1)):
                     yield j, k
 
     def _print_speedup(results):


### PR DESCRIPTION
python setup.py build/install --define="BYTETRACE, FOO, BAR=3"

will result in the the extra compiler args:
-DBYTETRACE=1 -DFOO=1 -DBAR=3

This will be needed to implement profiling (#8) 
