### PR TITLE
Fix stackoverflow error

### DIFF
--- a/src/_lrucache.c
+++ b/src/_lrucache.c
@@ -397,8 +397,8 @@ hashseq_arghash(hashseq *hs, Py_ssize_t len, int *ierr)
     y = PyObject_Hash(*p++);
     Py_LeaveRecursiveCall();
     if (y == -1){
-      if (PyObject_HasAttrString(*(p-1), "__hash__"))
-        *ierr = 1; // Object is hashable but we have an error
+      if (PyErr_GivenExceptionMatches(PyErr_Occurred(), PyExc_RuntimeError))
+        *ierr = 1;
       return -1;
     }
     x = (x ^ y) * mult;


### PR DESCRIPTION
Fixes #19. Following a `git checkout skirpichev_fastcache_test` on my sympy repo:
- On Master

``` bash
$ PYTHONHASHSEED=1542937067 bin/test sympy/core/tests/test_wester.py  --seed 13048593 -k test_Y7
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        13048593
hash randomization: on (PYTHONHASHSEED=1542937067)

sympy/core/tests/test_wester.py[1] Fatal Python error: Cannot recover from stack overflow.

Current thread 0x00007f32bdb91740 (most recent call first):
  File "/home/peter/git-codes/sympy/sympy/core/numbers.py", line 2590 in __hash__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 99 in __neg__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 117 in __sub__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 118 in binary_op_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 83 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 94 in _eval_sides
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 299 in __new__
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 259 in __gt__
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 77 in __sympifyit_wrapper
  File "/home/peter/git-codes/sympy/sympy/core/relational.py", line 617 in _eval_relation
  ...
Aborted (core dumped)
```
- PR

``` bash
$ PYTHONHASHSEED=1542937067 bin/test sympy/core/tests/test_wester.py  --seed 13048593 -k test_Y7
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        13048593
hash randomization: on (PYTHONHASHSEED=1542937067)

sympy/core/tests/test_wester.py[1] E                                      [FAIL]

________________________________________________________________________________
___________________ sympy/core/tests/test_wester.py:test_Y7 ____________________
  File "/home/peter/git-codes/sympy/sympy/core/tests/test_wester.py", line 2909,
 in test_Y7
    (n, 1, oo)), t, s)
  File "/home/peter/git-codes/sympy/sympy/integrals/transforms.py", line 1115, i
n laplace_transform
    return LaplaceTransform(f, t, s).doit(**hints)
  File "/home/peter/git-codes/sympy/sympy/integrals/transforms.py", line 117, in
 doit
    self.function_variable, self.transform_variable, **hints)
  File "/home/peter/git-codes/sympy/sympy/integrals/transforms.py", line 1063, i
n _compute_transform
....
<lots more output>
.....
  File "/home/peter/git-codes/sympy/sympy/core/tests/test_wester.py", line 2909,
 in test_Y7
    (n, 1, oo)), t, s)
  File "/home/peter/git-codes/sympy/sympy/integrals/transforms.py", line 1115, i
n laplace_transform
    return LaplaceTransform(f, t, s).doit(**hints)
  File "/home/peter/git-codes/sympy/sympy/integrals/transforms.py", line 117, in
 doit
    self.function_variable, self.transform_variable, **hints)
  File "/home/peter/git-codes/sympy/sympy/integrals/transforms.py", line 1063, i
n _compute_transform
[peter@localhost sympy]$ tail out
  File "/home/peter/git-codes/sympy/sympy/core/decorators.py", line 118, in binary_op_wrapper
    return func(self, other)
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 117, in __sub__
    return Add(self, -other)
  File "/home/peter/git-codes/sympy/sympy/core/expr.py", line 99, in __neg__
    return Mul(S.NegativeOne, self)
RuntimeError: maximum recursion depth exceeded

=========== tests finished: 0 passed, 1 exceptions, in 1.15 seconds ============
DO *NOT* COMMIT!
```

This PR adds the appropriate recursive checks around calls to PyObject_hash thus returning the appropriate error rather than aborting.
