### PR TITLE
allow attributes to be dynamically added to cacheobjects

### DIFF
--- a/src/_lrucache.c
+++ b/src/_lrucache.c
@@ -341,12 +341,15 @@ cache_get_doc(cacheobject * co, void *closure)
 static int
 restricted(void)
 {
+#ifdef _PY2
     if (!PyEval_GetRestricted())
+#endif
         return 0;
     PyErr_SetString(PyExc_RuntimeError,
         "function attributes not accessible in restricted mode");
     return 1;
 }
+
 
 static PyObject *
 func_get_dict(PyFunctionObject *op)


### PR DESCRIPTION
- On master

``` python
In [1]: from fastcache import clru_cache

In [2]: @clru_cache()
def f(a, b):
    """Docstring. """
    return (a, b)
   ...: 

In [3]: f._new_attr = 5
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-c03b9eef01c7> in <module>()
----> 1 f._new_attr = 5

AttributeError: 'fastcache.clru_cache' object has no attribute '_new_attr'
```
- PR

```
python
In [1]: from fastcache import clru_cache

In [2]: @clru_cache()
def f(a, b):
    """Docstring. """
    return (a, b)
   ...: 

In [3]: f._new_attr = 5

In [4]: f.__dict__
Out[4]: {'_new_attr': 5}

In [5]: f._new_attr
Out[5]: 5

In [6]: f.__getattribute__('_new_attr')
Out[6]: 5
```
