### PR TITLE
Improve py.test support

### DIFF
--- a/fastcache/__init__.py
+++ b/fastcache/__init__.py
@@ -74,7 +74,7 @@ def lru_cache(maxsize=128, typed=False, state=None, unhashable='error'):
 
     return func_wrapper
 
-def test():
+def test(*args):
     import pytest, os
-    return not pytest.cmdline.main(
-        [os.path.dirname(os.path.abspath(__file__))])
+    return not pytest.main([os.path.dirname(os.path.abspath(__file__))] +
+                           list(args))

--- a/fastcache/tests/test_clrucache.py
+++ b/fastcache/tests/test_clrucache.py
@@ -1,6 +1,7 @@
 import pytest
 import fastcache
 import itertools
+import warnings
 
 try:
     itertools.count(start=0, step=-1)
@@ -96,12 +97,14 @@ def test_warn_unhashable_args(cache, recwarn):
     def f(a, b):
         return (a, ) + (b, )
 
-    assert f([1], 2) == f.__wrapped__([1], 2)
-    w = recwarn.pop(UserWarning)
-    assert issubclass(w.category, UserWarning)
-    assert "Unhashable arguments cannot be cached" in str(w.message)
-    assert w.filename
-    assert w.lineno
+    with warnings.catch_warnings() :
+        warnings.simplefilter("always")
+        assert f([1], 2) == f.__wrapped__([1], 2)
+        w = recwarn.pop(UserWarning)
+        assert issubclass(w.category, UserWarning)
+        assert "Unhashable arguments cannot be cached" in str(w.message)
+        assert w.filename
+        assert w.lineno
 
 
 def test_ignore_unhashable_args(cache):


### PR DESCRIPTION
Allow arguments to be passed to test().

Ensure tests which are supposed to raise warnings do, by using the warnings.catch_warning context manager.

``` python
In [1]: import fastcache

In [2]: fastcache.test('-k', 'warn')
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
collected 29 items 

fastcache/tests/test_clrucache.py ..

======================= 27 tests deselected by '-kwarn' ========================
=================== 2 passed, 27 deselected in 0.10 seconds ====================
Out[2]: True

In [3]: fastcache.test('-k', 'warn')
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
collected 29 items 

fastcache/tests/test_clrucache.py ..

======================= 27 tests deselected by '-kwarn' ========================
=================== 2 passed, 27 deselected in 0.04 seconds ====================
Out[3]: True
```
