### PR TITLE
Change _PyObject_GC_TRACK to PyObject_GC_Track

### DIFF
--- a/src/_lrucache.c
+++ b/src/_lrucache.c
@@ -636,7 +636,7 @@ make_key(cacheobject *co, PyObject *args, PyObject *kw)
 
   Py_SIZE(lo) = size;
   lo->allocated = size;
-  _PyObject_GC_TRACK(hs);
+  PyObject_GC_Track(hs);
   // incorporate extra state
   if(is_list){
     for(i = 0; i < ex_size; i++){


### PR DESCRIPTION
Fixes #32 
According to https://docs.python.org/3/c-api/gcsupport.html
The macro version should not be used in extensions
