### PR TITLE
Use composition rather than inheritance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
 
 install: python setup.py install
 
 script: bash bin/test_travis.sh
-

--- a/fastcache/__init__.py
+++ b/fastcache/__init__.py
@@ -21,7 +21,7 @@ lru_cache  - python wrapper around clru_cache (slower)
            >>> <class 'function'>
 """
 
-__version__ = "1.0.2"
+__version__ = "1.0.2+git0"
 
 
 from ._lrucache import clru_cache

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ class BuildExt(_build_ext):
 
 
 setup(name = "fastcache",
-      version = "1.0.2",
+      version = "1.0.2+git0",
       description = "C implementation of Python 3 functools.lru_cache",
       long_description = long_description,
       author = "Peter Brady",


### PR DESCRIPTION
Replace hash_seq with HashedArgs.  HashedArgs contains a tuple to use as the key rather than subclassing list.  This allows us to remove some code.  Doesn't fix #42 yet.